### PR TITLE
fix: add build directory to vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,9 @@ export default defineConfig(({ command, mode, ssrBuild }) => {
         },
         react()
       ],
+      build: {
+        outDir: 'dist',
+      },
       publicDir: 'public',
       server: {
         watch: {


### PR DESCRIPTION
Attempting to fix public directory not accessible in deployed app